### PR TITLE
actually `use` exception classes

### DIFF
--- a/lib/ShardedKV/Storage/MySQL.pm
+++ b/lib/ShardedKV/Storage/MySQL.pm
@@ -5,6 +5,10 @@ use Moose;
 use Time::HiRes qw(sleep);
 use Carp ();
 
+use ShardedKV::Error::ConnectFail;
+use ShardedKV::Error::DeleteFail;
+use ShardedKV::Error::ReadFail;
+
 with 'ShardedKV::Storage';
 
 =attribute_public mysql_connector

--- a/lib/ShardedKV/Storage/Redis.pm
+++ b/lib/ShardedKV/Storage/Redis.pm
@@ -5,7 +5,9 @@ use Moose;
 use Encode;
 use Redis;
 use List::Util qw(shuffle);
+
 use ShardedKV::Error::ConnectFail;
+use ShardedKV::Error::DeleteFail;
 
 with 'ShardedKV::Storage';
 


### PR DESCRIPTION
this is to prevent errors like this:

Can't locate object method "throw" via package "ShardedKV::Error::ReadFail" (perhaps you forgot to load "ShardedKV::Error::ReadFail"?) at [snip]/ShardedKV/Storage/MySQL.pm line 344.
