### PR TITLE
use currying and a getter

### DIFF
--- a/lib/ShardedKV/Storage/Redis/Hash.pm
+++ b/lib/ShardedKV/Storage/Redis/Hash.pm
@@ -104,7 +104,7 @@ __END__
   );
   ... put storage into ShardedKV...
   
-  # values are scalar references to strings
+  # values are HashRefs
   $skv->set("foo", {bar => 'baz', cat => 'dog'});
   my $value_ref = $skv->get("foo");
 
@@ -115,8 +115,7 @@ simple string/blob values in Redis. See the documentation
 for C<ShardedKV::Storage::Redis> for the interface of this
 class.
 
-The values of a C<ShardedKV::Storage::Redis::Hash> are
-actually scalar references to strings.
+The values of a C<ShardedKV::Storage::Redis::Hash> are HashRefs.
 
 =head1 SEE ALSO
 

--- a/tools/benchmark.pl
+++ b/tools/benchmark.pl
@@ -1,0 +1,124 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use FindBin qw($Bin);
+
+use lib "$Bin/../lib";
+
+use Benchmark::Forking qw(cmpthese);
+
+use ShardedKV;
+use ShardedKV::Continuum::Ketama;
+use ShardedKV::Storage::Memory;
+
+my $continuum_spec = [
+    [shard1 => 100], # shard name, weight
+];
+my $continuum = ShardedKV::Continuum::Ketama->new(from => $continuum_spec);
+my %storages = (
+    shard1 => ShardedKV::Storage::Memory->new(
+      redis_connect_str => '127.0.0.1:6379',
+    ),
+);
+
+my $skv = ShardedKV->new(
+    storages => \%storages,
+    continuum => $continuum,
+);
+ 
+my $key = 'foo';
+my $value = \'bar';
+
+$skv->set($key, $value);
+$skv->get($key);
+my $getter = $skv->getter();
+$skv->set($key, $value);
+cmpthese(-5, {
+    'wit_acc' => sub { $skv->normal_get($key) },
+    'no_acc' => sub { $skv->get_no_accessors($key) },
+    'indirect_getter' => sub { $skv->get($key) },
+    'direct_getter' => sub { $$getter->($key) },
+});
+
+
+
+
+# This monkeypatching is for reference, this is what would be the get() method
+# if we were using accessors
+
+sub ShardedKV::normal_get {
+  my ($self, $key) = @_;
+  my $mig_cont = $self->migration_continuum;
+  my $cont = $self->continuum;
+
+  # dumb code for efficiency (otherwise, this would be a loop or in methods)
+
+  my $logger = $self->logger;
+  my $do_debug = $logger && $logger->is_debug ? 1 : 0;
+
+  my $storages = $self->storages;
+  my $chosen_shard;
+  my $value_ref;
+  if (defined $mig_cont) {
+    $chosen_shard = $mig_cont->choose($key);
+    $logger->debug("get() using migration continuum, got storage '$chosen_shard'") if $do_debug;
+    my $storage = $storages->{ $chosen_shard };
+    die "Failed to find chosen storage (server) for id '$chosen_shard' via key '$key'"
+      if not $storage;
+    $value_ref = $storage->get($key);
+  }
+
+  if (not defined $value_ref) {
+    my $where = $cont->choose($key);
+    $logger->debug("get() using regular continuum, got storage '$where'") if $do_debug;
+    if (!$chosen_shard or $where ne $chosen_shard) {
+      my $storage = $storages->{ $where };
+      die "Failed to find chosen storage (server) for id '$where' via key '$key'"
+        if not $storage;
+      $value_ref = $storage->get($key);
+    }
+  }
+
+  return $value_ref;
+}
+
+
+# This monkeypatching is for reference, this is the implementation bypassing accesors
+use Carp;
+
+sub ShardedKV::get_no_accessors {
+  my ($self, $key) = @_;
+  my ($mig_cont, $cont) = @{$self}{qw(migration_continuum continuum)};
+
+  # dumb code for efficiency (otherwise, this would be a loop or in methods)
+
+  my $logger = $self->{logger};
+  my $do_debug = ($logger and $logger->is_debug) ? 1 : 0;
+
+  my $storages = $self->{storages};
+  my $chosen_shard;
+  my $value_ref;
+  if (defined $mig_cont) {
+    $chosen_shard = $mig_cont->choose($key);
+    $logger->debug("get() using migration continuum, got storage '$chosen_shard'") if $do_debug;
+    my $storage = $storages->{ $chosen_shard };
+    croak "Failed to find chosen storage (server) for id '$chosen_shard' via key '$key'"
+      if not $storage;
+    $value_ref = $storage->get($key);
+  }
+
+  if (not defined $value_ref) {
+    my $where = $cont->choose($key);
+    $logger->debug("get() using regular continuum, got storage '$where'") if $do_debug;
+    if (!$chosen_shard or $where ne $chosen_shard) {
+      my $storage = $storages->{ $where };
+      croak "Failed to find chosen storage (server) for id '$where' via key '$key'"
+        if not $storage;
+      $value_ref = $storage->get($key);
+    }
+  }
+
+  return $value_ref;
+}
+


### PR DESCRIPTION
While providing a PR to fix connection reset (issue was that connection wasn't reset when it should in SharedKv code) I saw that the code is bypassing Moose accessor to use things like $self->{stuff} instead of $self->stuff. That's for speed purpose ( my benchmark shows it's 20% faster than using accessors in this particular code). 

However this is imho very dangerous. It basically vorbid anyone to build other modules to extend this one. method modifiers, triggers, attribute features are not going to work properly. Introspection and meta won't work either.

Here I propose a different approach, by using currying and some Moose attribute features so it uses accessors to build a Coderef specialized for a given instance. When this instance is changed (very rarely), for instance begin migration, extend shard, etc the Coderef is rebuilt, still using the accessors.

With my implementation, using ->get() is marginally faster than before. However, using `my $getter = $self->getter;` then later on doing `$$getter->($key)`, is 50% faster. And it works well with migration etc, as the CoderRef can be rebuilt behind the scene.

I've provided a small benchmark in tools. Maybe it's not a fair benchmark, but I believe it is good enough. Here are the results (master implementation is "no_acc"):

<pre>
                    Rate      wit_acc       no_acc indirect_getter direct_getter
wit_acc         236307/s           --         -26%            -30%          -51%
no_acc          320145/s          35%           --             -6%          -34%
indirect_getter 338841/s          43%           6%              --          -30%
direct_getter   486720/s         106%          52%             44%            --
</pre>
